### PR TITLE
feat/環境構築

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -16,6 +16,9 @@ android {
         versionName = "1.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        vectorDrawables {
+            useSupportLibrary = true
+        }
     }
 
     buildTypes {
@@ -28,19 +31,26 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_11
-        targetCompatibility = JavaVersion.VERSION_11
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = "11"
+        jvmTarget = "17"
     }
     buildFeatures {
         compose = true
     }
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+    lint {
+        abortOnError = true
+    }
 }
 
 dependencies {
-
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)
@@ -49,6 +59,7 @@ dependencies {
     implementation(libs.androidx.compose.ui.graphics)
     implementation(libs.androidx.compose.ui.tooling.preview)
     implementation(libs.androidx.compose.material3)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)


### PR DESCRIPTION
ビルド、lint、テストが通ることを確認
```
 kawaiyuya@MacBook-Air  ~/AndroidStudioProjects/smartphonelock   main ±✚  ./gradlew clean assembleDebug
Starting a Gradle Daemon, 1 incompatible Daemon could not be reused, use --status for details

> Task :app:stripDebugDebugSymbols
Unable to strip the following libraries, packaging them as they are: libandroidx.graphics.path.so. Run with --info option to learn more.

BUILD SUCCESSFUL in 11s
38 actionable tasks: 38 executed
 kawaiyuya@MacBook-Air  ~/AndroidStudioProjects/smartphonelock   main ±✚  ./gradlew lint

> Task :app:lintReportDebug
Wrote HTML report to file:///Users/kawaiyuya/AndroidStudioProjects/smartphonelock/app/build/reports/lint-results-debug.html

BUILD SUCCESSFUL in 21s
28 actionable tasks: 11 executed, 17 up-to-date
 kawaiyuya@MacBook-Air  ~/AndroidStudioProjects/smartphonelock   main ±✚  ./gradlew testDebugUnitTest

BUILD SUCCESSFUL in 1s
24 actionable tasks: 5 executed, 19 up-to-date
```