### PR TITLE
許可アプリ利用後のホーム復帰時オーバーレイ再表示を高速化

### DIFF
--- a/app/src/debug/java/jp/kawai/ultrafocus/receiver/TestControlReceiver.kt
+++ b/app/src/debug/java/jp/kawai/ultrafocus/receiver/TestControlReceiver.kt
@@ -5,10 +5,12 @@ import android.content.Context
 import android.content.Intent
 import android.util.Log
 import jp.kawai.ultrafocus.data.datastore.DataStoreManager
+import jp.kawai.ultrafocus.service.AllowedAppLaunchStore
 import jp.kawai.ultrafocus.service.LockMonitorService
 import jp.kawai.ultrafocus.service.OverlayLockService
 import jp.kawai.ultrafocus.service.WatchdogScheduler
 import jp.kawai.ultrafocus.service.WatchdogWorkScheduler
+import jp.kawai.ultrafocus.util.AllowedAppResolver
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 import kotlinx.coroutines.runBlocking
@@ -34,6 +36,7 @@ class TestControlReceiver : BroadcastReceiver() {
             ACTION_TEST_LOCK -> handleLock(appContext, intent)
             ACTION_TEST_UNLOCK -> handleUnlock(appContext)
             ACTION_TEST_STATUS -> logStatus(appContext)
+            ACTION_TEST_PREPARE_ALLOWED_DIALER -> handlePrepareAllowedDialer(appContext)
         }
     }
 
@@ -62,12 +65,36 @@ class TestControlReceiver : BroadcastReceiver() {
         runBlocking {
             dataStoreManager.updateLockState(false, null, null)
         }
+        AllowedAppLaunchStore.clear(context)
         WatchdogScheduler.cancelHeartbeat(context)
         WatchdogScheduler.cancelLockExpiry(context)
         WatchdogWorkScheduler.cancel(context)
         LockMonitorService.stop(context)
         OverlayLockService.stop(context)
         Log.i(TAG, "Test unlock executed")
+    }
+
+    private fun handlePrepareAllowedDialer(context: Context) {
+        val targetPackage = AllowedAppResolver.resolveDialerPackage(context)
+        if (targetPackage.isNullOrBlank()) {
+            AllowedAppLaunchStore.clear(context)
+            OverlayLockService.setAllowedAppSuppressed(
+                context,
+                suppressed = false,
+                reason = "test_prepare_allowed_dialer_failed"
+            )
+            Log.w(TAG, "No default dialer resolved for test preparation")
+            return
+        }
+        OverlayLockService.setAllowedAppSuppressed(
+            context,
+            suppressed = true,
+            reason = "test_prepare_allowed_dialer"
+        )
+        AllowedAppLaunchStore.startLaunch(context)
+        AllowedAppLaunchStore.startSession(context)
+        AllowedAppLaunchStore.setAllowed(context, targetPackage)
+        Log.i(TAG, "Prepared allowed dialer package=$targetPackage")
     }
 
     private fun logStatus(context: Context) {
@@ -79,6 +106,8 @@ class TestControlReceiver : BroadcastReceiver() {
         const val ACTION_TEST_LOCK = "jp.kawai.ultrafocus.action.TEST_LOCK"
         const val ACTION_TEST_UNLOCK = "jp.kawai.ultrafocus.action.TEST_UNLOCK"
         const val ACTION_TEST_STATUS = "jp.kawai.ultrafocus.action.TEST_STATUS"
+        const val ACTION_TEST_PREPARE_ALLOWED_DIALER =
+            "jp.kawai.ultrafocus.action.TEST_PREPARE_ALLOWED_DIALER"
         const val EXTRA_DURATION_MINUTES = "extra_duration_minutes"
         const val EXTRA_END_TIMESTAMP = "extra_end_timestamp"
         private const val DEFAULT_MINUTES = 10L

--- a/app/src/debug/java/jp/kawai/ultrafocus/receiver/TestControlReceiver.kt
+++ b/app/src/debug/java/jp/kawai/ultrafocus/receiver/TestControlReceiver.kt
@@ -78,6 +78,7 @@ class TestControlReceiver : BroadcastReceiver() {
         val targetPackage = AllowedAppResolver.resolveDialerPackage(context)
         if (targetPackage.isNullOrBlank()) {
             AllowedAppLaunchStore.clear(context)
+            LockMonitorService.syncAllowedAppMonitorMode(context)
             OverlayLockService.setAllowedAppSuppressed(
                 context,
                 suppressed = false,
@@ -94,6 +95,7 @@ class TestControlReceiver : BroadcastReceiver() {
         AllowedAppLaunchStore.startLaunch(context)
         AllowedAppLaunchStore.startSession(context)
         AllowedAppLaunchStore.setAllowed(context, targetPackage)
+        LockMonitorService.syncAllowedAppMonitorMode(context)
         Log.i(TAG, "Prepared allowed dialer package=$targetPackage")
     }
 

--- a/app/src/main/java/jp/kawai/ultrafocus/service/ForegroundAppMonitor.kt
+++ b/app/src/main/java/jp/kawai/ultrafocus/service/ForegroundAppMonitor.kt
@@ -5,6 +5,8 @@ import kotlinx.coroutines.CoroutineScope
 /**
  * 前面アプリの状態を監視し、フォアグラウンド遷移を通知するコンポーネント。
  */
-fun interface ForegroundAppMonitor {
+interface ForegroundAppMonitor {
     fun start(scope: CoroutineScope, onMoveToForeground: (String) -> Unit)
+
+    fun setHighFrequencyMode(enabled: Boolean)
 }

--- a/app/src/main/java/jp/kawai/ultrafocus/service/LockMonitorService.kt
+++ b/app/src/main/java/jp/kawai/ultrafocus/service/LockMonitorService.kt
@@ -17,6 +17,7 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
+import jp.kawai.ultrafocus.BuildConfig
 import jp.kawai.ultrafocus.R
 import jp.kawai.ultrafocus.data.repository.LockRepository
 import jp.kawai.ultrafocus.data.repository.SettingsPackages
@@ -239,12 +240,31 @@ class LockMonitorService : Service() {
             if (launchInProgress && !allowedAppForeground) {
                 return
             }
+            if (BuildConfig.DEBUG) {
+                val nowWallTime = System.currentTimeMillis()
+                Log.i(
+                    TAG,
+                    "perf_home_overlay step=allowed_app_home_detected package=$packageName " +
+                        "wallTimeMillis=$nowWallTime elapsedRealtime=$nowElapsed " +
+                        "sessionActive=$sessionActive launchInProgress=$launchInProgress " +
+                        "allowedAppForeground=$allowedAppForeground"
+                )
+            }
             sessionActive = false
             allowedAppForeground = false
             lastAllowedAppSeenElapsed = 0L
             pendingAllowedSessionExitPackage = null
             pendingAllowedSessionExitStartedAt = 0L
             AllowedAppLaunchStore.clear(this@LockMonitorService)
+            if (BuildConfig.DEBUG) {
+                val requestWallTime = System.currentTimeMillis()
+                val requestElapsed = SystemClock.elapsedRealtime()
+                Log.i(
+                    TAG,
+                    "perf_home_overlay step=overlay_release_requested package=$packageName " +
+                        "wallTimeMillis=$requestWallTime elapsedRealtime=$requestElapsed"
+                )
+            }
             OverlayLockService.setAllowedAppSuppressed(this@LockMonitorService, false)
             if (!inPermissionRecoverySettings) {
                 overlayManager.show(bypassDebounce = true)

--- a/app/src/main/java/jp/kawai/ultrafocus/service/LockMonitorService.kt
+++ b/app/src/main/java/jp/kawai/ultrafocus/service/LockMonitorService.kt
@@ -80,6 +80,7 @@ class LockMonitorService : Service() {
         super.onCreate()
         createNotificationChannel()
         acquireWakeLock()
+        foregroundAppMonitor.setHighFrequencyMode(false)
     }
 
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
@@ -111,6 +112,7 @@ class LockMonitorService : Service() {
 
         acquireWakeLock()
         lockRepository.refreshDynamicLists()
+        syncForegroundMonitorMode()
         val foregroundReady = ensureForeground(reason, force = requireForeground)
         if (requireForeground && !foregroundReady) {
             Log.w(TAG, "Foreground start failed after startForegroundService; stopping service")
@@ -126,6 +128,7 @@ class LockMonitorService : Service() {
 
     override fun onDestroy() {
         super.onDestroy()
+        foregroundAppMonitor.setHighFrequencyMode(false)
         serviceScope.cancel()
         releaseWakeLock()
         lockStateJob = null
@@ -182,6 +185,7 @@ class LockMonitorService : Service() {
         isLocked = nextState
         if (!nextState) {
             allowedAppForeground = false
+            foregroundAppMonitor.setHighFrequencyMode(false)
         }
         if (nextState) {
             // ロック開始時は確実に即時オーバーレイを掲出したいのでデバウンスを無視する
@@ -189,9 +193,17 @@ class LockMonitorService : Service() {
         }
     }
 
+    private fun syncForegroundMonitorMode(
+        launchInProgress: Boolean = AllowedAppLaunchStore.isLaunchInProgress(this@LockMonitorService),
+        sessionActive: Boolean = AllowedAppLaunchStore.isSessionActive(this@LockMonitorService),
+    ) {
+        foregroundAppMonitor.setHighFrequencyMode(launchInProgress || sessionActive || allowedAppForeground)
+    }
+
     private suspend fun handleForegroundPackage(packageName: String) {
         val nowElapsed = SystemClock.elapsedRealtime()
         if (EmergencyUnlockState.isActive() || EmergencyUnlockStateStore.isActive(this@LockMonitorService)) {
+            foregroundAppMonitor.setHighFrequencyMode(false)
             if (packageName != this.packageName) {
                 redirectToEmergencyUnlock(packageName, reason = "foreground_detected")
             }
@@ -199,6 +211,7 @@ class LockMonitorService : Service() {
         }
         val launchInProgress = AllowedAppLaunchStore.isLaunchInProgress(this@LockMonitorService)
         var sessionActive = AllowedAppLaunchStore.isSessionActive(this@LockMonitorService)
+        syncForegroundMonitorMode(launchInProgress = launchInProgress, sessionActive = sessionActive)
 
         if (launchInProgress &&
             (packageName == this.packageName ||
@@ -218,6 +231,7 @@ class LockMonitorService : Service() {
         val isTemporarilyAllowed = AllowedAppLaunchStore.isAllowed(this, packageName)
         val isAllowedApp = allowedTargets.isAllowed(packageName) || isTemporarilyAllowed
         if (isAllowedApp) {
+            foregroundAppMonitor.setHighFrequencyMode(true)
             allowedAppForeground = true
             lastAllowedAppSeenElapsed = nowElapsed
             pendingAllowedSessionExitPackage = null
@@ -256,6 +270,7 @@ class LockMonitorService : Service() {
             pendingAllowedSessionExitPackage = null
             pendingAllowedSessionExitStartedAt = 0L
             AllowedAppLaunchStore.clear(this@LockMonitorService)
+            foregroundAppMonitor.setHighFrequencyMode(false)
             if (BuildConfig.DEBUG) {
                 val requestWallTime = System.currentTimeMillis()
                 val requestElapsed = SystemClock.elapsedRealtime()
@@ -281,6 +296,7 @@ class LockMonitorService : Service() {
                 pendingAllowedSessionExitPackage = null
                 pendingAllowedSessionExitStartedAt = 0L
                 AllowedAppLaunchStore.clear(this@LockMonitorService)
+                foregroundAppMonitor.setHighFrequencyMode(false)
                 OverlayLockService.setAllowedAppSuppressed(this@LockMonitorService, false)
                 if (!inPermissionRecoverySettings) {
                     overlayManager.show(bypassDebounce = true)
@@ -296,6 +312,7 @@ class LockMonitorService : Service() {
             pendingAllowedSessionExitPackage = null
             pendingAllowedSessionExitStartedAt = 0L
             AllowedAppLaunchStore.clear(this@LockMonitorService)
+            foregroundAppMonitor.setHighFrequencyMode(false)
             OverlayLockService.setAllowedAppSuppressed(this@LockMonitorService, false)
             if (!inPermissionRecoverySettings) {
                 overlayManager.show(bypassDebounce = true)
@@ -512,6 +529,7 @@ class LockMonitorService : Service() {
         private const val RESTART_DEBOUNCE_MILLIS = 3_000L
         private const val FOREGROUND_RETRY_INTERVAL_MILLIS = 30_000L
         private const val RESTART_REASON = "service_restart"
+        private const val ALLOWED_APP_MONITOR_MODE_SYNC_REASON = "allowed_app_monitor_mode_sync"
         private const val WAKE_LOCK_TIMEOUT_MILLIS = 180_000L
         private const val EXTRA_START_REASON = "extra_start_reason"
         private const val EXTRA_REQUESTED_AT = "extra_requested_at"
@@ -560,6 +578,14 @@ class LockMonitorService : Service() {
         fun stop(context: Context) {
             val intent = Intent(context, LockMonitorService::class.java)
             context.stopService(intent)
+        }
+
+        fun syncAllowedAppMonitorMode(context: Context) {
+            start(
+                context = context,
+                reason = ALLOWED_APP_MONITOR_MODE_SYNC_REASON,
+                bypassDebounce = true
+            )
         }
 
         private fun shouldDebounce(reason: String?, bypass: Boolean): Boolean {

--- a/app/src/main/java/jp/kawai/ultrafocus/service/OverlayLockService.kt
+++ b/app/src/main/java/jp/kawai/ultrafocus/service/OverlayLockService.kt
@@ -610,6 +610,15 @@ class OverlayLockService : Service() {
             container.isFocusable = false
         }
         windowManager.addView(container, layoutParams)
+        if (BuildConfig.DEBUG) {
+            Log.i(
+                TAG,
+                "perf_home_overlay step=overlay_visible_again path=add_view " +
+                    "wallTimeMillis=${System.currentTimeMillis()} " +
+                    "elapsedRealtime=${SystemClock.elapsedRealtime()} " +
+                    "overlayAlreadyExists=false"
+            )
+        }
         if (allowedAppSuppressed) {
             applyOverlaySuppressionState(suppressed = true)
         }
@@ -676,6 +685,7 @@ class OverlayLockService : Service() {
             applyOverlaySuppressionState(suppressed = true)
             return
         }
+        val overlayAlreadyExists = overlayContainer != null
         if (allowedAppSuppressed == suppressed) {
             allowedAppSuppressedAtElapsed = 0L
             return
@@ -687,6 +697,15 @@ class OverlayLockService : Service() {
             showOverlayIfNeeded()
         }
         applyOverlaySuppressionState(suppressed = false)
+        if (BuildConfig.DEBUG && overlayAlreadyExists) {
+            Log.i(
+                TAG,
+                "perf_home_overlay step=overlay_visible_again path=unsuppress " +
+                    "wallTimeMillis=${System.currentTimeMillis()} " +
+                    "elapsedRealtime=${SystemClock.elapsedRealtime()} " +
+                    "overlayAlreadyExists=true"
+            )
+        }
         updateOverlayModeIfNeeded(mode)
     }
 

--- a/app/src/main/java/jp/kawai/ultrafocus/service/UsageStatsForegroundAppEventSource.kt
+++ b/app/src/main/java/jp/kawai/ultrafocus/service/UsageStatsForegroundAppEventSource.kt
@@ -4,6 +4,7 @@ import android.app.usage.UsageEvents
 import android.app.usage.UsageStatsManager
 import android.content.Context
 import android.util.Log
+import jp.kawai.ultrafocus.BuildConfig
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -30,6 +31,13 @@ class UsageStatsForegroundAppEventSource @Inject constructor(
             while (usageEvents.hasNextEvent()) {
                 usageEvents.getNextEvent(event)
                 if (event.eventType == UsageEvents.Event.MOVE_TO_FOREGROUND && !event.packageName.isNullOrBlank()) {
+                    if (BuildConfig.DEBUG) {
+                        Log.i(
+                            TAG,
+                            "perf_home_overlay step=launcher_usage_event package=${event.packageName} " +
+                                "eventTimeMillis=${event.timeStamp} observedWallTimeMillis=$end"
+                        )
+                    }
                     onEvent(event.packageName)
                 }
             }

--- a/app/src/main/java/jp/kawai/ultrafocus/service/UsageWatcher.kt
+++ b/app/src/main/java/jp/kawai/ultrafocus/service/UsageWatcher.kt
@@ -1,6 +1,7 @@
 package jp.kawai.ultrafocus.service
 
 import android.util.Log
+import jp.kawai.ultrafocus.BuildConfig
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlin.coroutines.coroutineContext
@@ -8,9 +9,13 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.selects.onTimeout
+import kotlinx.coroutines.selects.select
 
 /**
  * UsageStats ベースでフォアグラウンドアプリを監視する実装。
@@ -20,6 +25,11 @@ class UsageWatcher @Inject constructor(
     private val eventSource: ForegroundAppEventSource,
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) : ForegroundAppMonitor {
+
+    private val modeChangeSignals = Channel<Unit>(Channel.CONFLATED)
+
+    @Volatile
+    private var currentPollingIntervalMillis: Long = POLL_INTERVAL_MILLIS
 
     override fun start(scope: CoroutineScope, onMoveToForeground: (String) -> Unit) {
         if (watchJobActive) {
@@ -37,6 +47,21 @@ class UsageWatcher @Inject constructor(
         job.invokeOnCompletion { watchJobActive = false }
     }
 
+    override fun setHighFrequencyMode(enabled: Boolean) {
+        val nextInterval = if (enabled) HIGH_FREQUENCY_POLL_INTERVAL_MILLIS else POLL_INTERVAL_MILLIS
+        if (currentPollingIntervalMillis == nextInterval) return
+        currentPollingIntervalMillis = nextInterval
+        modeChangeSignals.trySend(Unit)
+        if (BuildConfig.DEBUG) {
+            Log.d(
+                TAG,
+                "home_overlay_monitor step=mode_changed highFrequency=$enabled " +
+                    "pollIntervalMillis=$nextInterval"
+            )
+        }
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     private suspend fun pollUsageEvents(onMoveToForeground: (String) -> Unit) {
         var lastKnownForeground: String? = null
         while (coroutineContext.isActive) {
@@ -61,13 +86,17 @@ class UsageWatcher @Inject constructor(
             } catch (throwable: Throwable) {
                 Log.e(TAG, "Unexpected error while polling usage events", throwable)
             }
-            delay(POLL_INTERVAL_MILLIS)
+            select<Unit> {
+                modeChangeSignals.onReceive { }
+                onTimeout(currentPollingIntervalMillis) { }
+            }
         }
     }
 
     companion object {
         private const val TAG = "UsageWatcher"
         internal const val POLL_INTERVAL_MILLIS = 750L
+        internal const val HIGH_FREQUENCY_POLL_INTERVAL_MILLIS = 250L
         internal const val QUERY_WINDOW_MILLIS = 2_000L
         internal const val PERMISSION_RETRY_DELAY_MILLIS = 5_000L
 


### PR DESCRIPTION
## 概要

- ロック中に許可アプリを利用したあと、ホーム画面へ戻った際のオーバーレイ再表示を高速化しました。
- 主な変更は、許可アプリ利用中のみ前面アプリ監視の polling 間隔を短縮し、ホーム復帰の検知遅延を抑えるものです。通常時は従来どおりの監視頻度を維持し、負荷増加が常時発生しないようにしています。

## 変更内容
- `ForegroundAppMonitor` に監視頻度切り替えAPIを追加
- `UsageWatcher` で通常監視 750ms / 高頻度監視 250ms を切り替え
- 許可アプリの起動中・利用中のみ高頻度監視へ切り替え
- ホーム復帰、許可外アプリ遷移、ロック解除、緊急解除、Service終了時に通常監視へ戻すよう整理
- debugビルド向けにホーム復帰・オーバーレイ再表示の計測ログを追加
- adb計測用に許可ダイヤラー準備コマンドを追加
- ロックドメインのクラス図ドキュメントを追加

## 確認結果
手元計測では、許可アプリ利用後にホームへ戻ってからオーバーレイが再表示されるまでの中央値が短縮されました。
- 改善前: 663ms
- 改善後: 244ms
- 差分: -419ms

検知遅延も以下の通り短縮
- 改善前: 654ms
- 改善後: 233ms
- 差分: -421ms